### PR TITLE
Improve responsiveness of homepage video elements

### DIFF
--- a/style.css
+++ b/style.css
@@ -222,8 +222,9 @@ table{
 }
 
 .video-crop{
-    width:  33.33%;
+    flex: 1 1 auto;
     overflow: hidden;
+    position: relative;
 }
 
 .main-video{
@@ -271,50 +272,31 @@ table{
 .video-crop div{
     position: absolute;
     top: 50%;
+    left: 50%;
+    transform: translate(-50%, -25%);
     z-index: 1;
     color: white !important;
+
+    /* Center icons above text */
+    display: flex;
+    flex-flow: column nowrap;
+    align-items: center;
 }
 
-.mplus-text{
-    margin-left: 16em;
-    margin-top: -1em;
-}
-
-.raid-text{
-    margin-left: 8em;
-    margin-top: -1em;
-}
-
-.pvp-text{
-    margin-left: 15em;
-    margin-top: -1em;
-    
-}
 
 /* Over-video icons */
 
 .raid-icon{
-    position: relative;
-    left: 10em;
-    bottom: 1em;
     filter: drop-shadow(0 0 15px #ff8447);
 }
 
 .mplus-icon{
-    position: relative;
-    left: 1.5em;
-    bottom: 2em;
     width: 5em;
-    margin-bottom: -2em;
     filter: drop-shadow(0 0 17px #ff8447);
 }
 
 .pvp-icon{
-    position: relative;
-    left: 3em;
     width: 5em;
-    bottom: 1em;
-    margin-bottom: -1em;
     filter: drop-shadow(0 0 18px #ff732d);
 }
 


### PR DESCRIPTION
Leverage more of flexbox's centering capabilities, and use an old css hack with absolute position + transform-translate to position items over the videos.